### PR TITLE
feat: support filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +205,21 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -457,6 +481,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +522,7 @@ dependencies = [
  "bytes",
  "clap",
  "dirs",
+ "fancy-regex",
  "hexplay",
  "http",
  "http-body-util",
@@ -1113,6 +1149,23 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ async-compression = { version = "0.4.6", features = ["brotli", "gzip", "deflate"
 bytes = "1.5"
 clap = { version = "4.5.1", features = ["derive"] }
 dirs = "5.0.1"
+fancy-regex = "0.13.0"
 hexplay = "0.3.0"
 http = "1.1.0"
 http-body-util = "0.1"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@ Forproxy can decrypt encrypted traffic on the fly, as long as the client trusts 
 
 The forproxy CA cert is located in `~/.forproxy` after it has been generated at the first start of forproxy.
 
+## CLI
+
+```
+Usage: forproxy [OPTIONS] [URL]
+
+Arguments:
+  [URL]  Proxy target
+
+Options:
+  -b, --bind <ADDR>           Specify address to listen on [default: 0.0.0.0]
+  -p, --port <PORT>           Specify port to listen on [default: 8088]
+  -f, --filters <REGEX>       Only inspect connections whose title(`{method} {uri}`) matches the regexe
+  -t, --type-filters <VALUE>  Only inspect connections whose content-type matches the value
+  -h, --help                  Print help
+  -V, --version               Print version
+```
+
+### Filter
+
+Use `-f/--filters` to filter connections by title (`{method} {uri}`).
+
+```
+tproxy -f httpbin.org -f postman-echo.com
+tproxy -f '/^(get|post) https:\/\/httpbin.org/'
+```
+
+Use `-t/--type-filters` to filter connections by content-type
+```
+tproxy -t application/json
+```
+
 ## License
 
 Copyright (c) 2024-∞ forproxy-developers.

--- a/README.md
+++ b/README.md
@@ -48,35 +48,18 @@ Forproxy can decrypt encrypted traffic on the fly, as long as the client trusts 
 
 The forproxy CA cert is located in `~/.forproxy` after it has been generated at the first start of forproxy.
 
-## CLI
-
-```
-Usage: forproxy [OPTIONS] [URL]
-
-Arguments:
-  [URL]  Proxy target
-
-Options:
-  -b, --bind <ADDR>           Specify address to listen on [default: 0.0.0.0]
-  -p, --port <PORT>           Specify port to listen on [default: 8088]
-  -f, --filters <REGEX>       Only inspect connections whose title(`{method} {uri}`) matches the regexe
-  -t, --type-filters <VALUE>  Only inspect connections whose content-type matches the value
-  -h, --help                  Print help
-  -V, --version               Print version
-```
-
-### Filter
+## Filter
 
 Use `-f/--filters` to filter connections by title (`{method} {uri}`).
 
 ```
-tproxy -f httpbin.org -f postman-echo.com
-tproxy -f '/^(get|post) https:\/\/httpbin.org/'
+forproxy -f httpbin.org -f postman-echo.com
+forproxy -f '/^(get|post) https:\/\/httpbin.org/'
 ```
 
 Use `-t/--type-filters` to filter connections by content-type
 ```
-tproxy -t application/json
+forproxy -t application/json
 ```
 
 ## License

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,70 @@
+use anyhow::{Context, Result};
+use fancy_regex::Regex;
+
+pub(crate) fn parse_filters(filters: &[String]) -> Result<Vec<Filter>> {
+    let mut output = vec![];
+    for filter in filters {
+        if let Some(re) = filter.strip_prefix('/').and_then(|v| v.strip_suffix('/')) {
+            let regex = Regex::new(&re.to_lowercase())
+                .with_context(|| format!("Invalid filter regex: {filter}"))?;
+            output.push(Filter::Regex(regex));
+        } else {
+            output.push(Filter::Plain(filter.to_lowercase()));
+        }
+    }
+    Ok(output)
+}
+
+pub(crate) fn is_match_title(filters: &[Filter], title: &str) -> bool {
+    if filters.is_empty() {
+        true
+    } else {
+        let title = title.to_lowercase();
+        filters.iter().any(|v| v.is_match(&title))
+    }
+}
+
+pub(crate) fn is_match_type(filters: &[String], content_type: &str) -> bool {
+    if filters.is_empty() {
+        true
+    } else {
+        let content_type = content_type.to_lowercase();
+        filters.iter().any(|v| content_type.starts_with(v))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum Filter {
+    Regex(Regex),
+    Plain(String),
+}
+
+impl Filter {
+    pub(crate) fn is_match(&self, value: &str) -> bool {
+        match self {
+            Filter::Regex(v) => v.is_match(value).unwrap_or_default(),
+            Filter::Plain(v) => value.contains(v),
+        }
+    }
+}
+
+#[test]
+fn test_filters() {
+    let filters = parse_filters(&[
+        "postman-echo.com".to_string(),
+        "/^(GET|POST) https:\\/\\/httpbin.org/".to_string(),
+    ])
+    .unwrap();
+    assert!(is_match_title(&filters, "GET https://postman-echo.com/get"));
+    assert!(is_match_title(&filters, "GET https://httpbin.org"));
+    assert!(is_match_title(&filters, "POST https://httpbin.org"));
+    assert!(!is_match_title(&filters, "PUT https://httpbin.org"));
+}
+
+#[test]
+fn test_is_asset() {
+    let filters = vec!["application/json".to_string()];
+    assert!(is_match_type(&filters, "application/json"));
+    let filters = vec!["application/".to_string()];
+    assert!(is_match_type(&filters, "application/json"));
+}


### PR DESCRIPTION
Use `-f/--filters` to filter connections by title (`{method} {uri}`).

```
forproxy -f httpbin.org -f postman-echo.com
forproxy -f '/^(get|post) https:\/\/httpbin.org/'
```

Use `-t/--type-filters` to filter connections by content-type
```
forproxy -t application/json
```